### PR TITLE
Fix header file generator

### DIFF
--- a/contrib/cl2hdr.c
+++ b/contrib/cl2hdr.c
@@ -38,11 +38,16 @@ int main(int argc, char * argv[])
             // if we're a single-line comment
             if(last_is_slash && ibuf[i] == '/') {
                 is_slc = 1;
+                // only can be true if we're not a comment, which we are now
+                last_is_slash = 0;
                 continue;
             }
 
+            // if we're a multi-line comment
             if(last_is_slash && ibuf[i] == '*') {
                 is_mlc = 1;
+                // only can be true if we're not a comment, which we are now
+                last_is_slash = 0;
                 continue;
             }
 


### PR DESCRIPTION
These fixes for the header file generator result in a smaller KERNEL_STRING, prevent some nefarious corner-cases from breaking things, and can successfully parse likefunc.cpp into a #define, which can be printed via redirection into a new likefunc.cpp, which can then be used to build a HYPHY executable that can successfully run every test I've thrown at it in tests/hbltests/SimpleOptimizations. Seeing as likefunc.cpp is our longest and most formatting-silly file, this is a good test of cl2hdr's abilities.
