### PR TITLE
Misc fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -162,7 +162,7 @@ endif(CMAKE_SIZEOF_VOID_P EQUAL 8)
 include_directories(
     src/core/include
     src/lib/Link src/new/include
-    contrib # SQLite
+    contrib/SQLite-3.6.17 # SQLite
     src/gui/include
     src/gui/include/Components
     src/gui/include/WindowClasses

--- a/src/core/batchlan2.cpp
+++ b/src/core/batchlan2.cpp
@@ -33,7 +33,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 #endif
 
 #ifndef __HYPHY_NO_SQLITE__
-#include "SQLite-3.6.17/sqlite3.h"
+#include "sqlite3.h"
 #endif
 
 #if !defined __HEADLESS__

--- a/src/gui/include/WindowClasses/HYDBWindow.h
+++ b/src/gui/include/WindowClasses/HYDBWindow.h
@@ -10,7 +10,7 @@
 
 #include "HYTableWindow.h"
 #include "HYTableComponent.h"
-#include "SQLite-3.6.17/sqlite3.h"
+#include "sqlite3.h"
 
 
 //__________________________________________________________________


### PR DESCRIPTION
Fixes for linking to dl (older linux systems), keeping the buildtime-generated ocl header file out of the repo, and using the included SQLite-3.6.17 header files 
