### PR TITLE
Allow single-threaded builds in CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -216,6 +216,21 @@ install(
 )
 add_custom_target(MP2 DEPENDS HYPHYMP)
 
+#-------------------------------------------------------------------------------
+# hyphy sp target
+#-------------------------------------------------------------------------------
+add_executable(
+    HYPHYSP
+    EXCLUDE_FROM_ALL
+    ${SRC_COMMON} ${SRC_UNIXMAIN}
+)
+target_link_libraries(HYPHYSP ${DEFAULT_LIBRARIES})
+install(
+    TARGETS HYPHYSP
+    RUNTIME DESTINATION bin
+    OPTIONAL
+)
+add_custom_target(SP DEPENDS HYPHYSP)
 
 #-------------------------------------------------------------------------------
 # hyphy OpenCL target
@@ -395,7 +410,7 @@ endif((${GTK2_FOUND}))
 #-------------------------------------------------------------------------------
 if(UNIX)
     set_property(
-        TARGET HYPHYMP hyphy_mp HYPHYGTEST HYPHYDEBUG
+        TARGET HYPHYMP hyphy_mp HYPHYGTEST HYPHYDEBUG HYPHYSP
         APPEND PROPERTY COMPILE_DEFINITIONS __UNIX__
     )
 endif(UNIX)
@@ -406,13 +421,20 @@ set_property(
 )
 
 set_property(
-    TARGET hyphy_mp HYPHYMP HYPHYGTEST HYPHYDEBUG
+    TARGET hyphy_mp HYPHYMP HYPHYGTEST HYPHYDEBUG HYPHYSP
     APPEND PROPERTY COMPILE_DEFINITIONS _HYPHY_LIBDIRECTORY_="${CMAKE_INSTALL_PREFIX}/lib/hyphy"
 )
 
 set_property(
     TARGET HYPHYDEBUG HYPHYGTEST
     APPEND PROPERTY COMPILE_DEFINITIONS __HYPHYDEBUG__
+)
+
+set_target_properties(
+    HYPHYSP
+    PROPERTIES
+    COMPILE_FLAGS "${DEFAULT_COMPILE_FLAGS}"
+    LINK_FLAGS "${DEFAULT_LINK_FLAGS}"
 )
 
 set_target_properties(

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ then just `make` away with one of the following targets:
 
 +   MAC - build a Mac Carbon application
 +   HYPHYGTK - HYPHY with GTK
++   SP - build a HyPhy executable (HYPHYSP) without multiprocessing
 +   MP2 - build a HyPhy executable (HYPHYMP) using pthreads to do multiprocessing
 +   MPI - build a HyPhy executable (HYPHYMPI) using MPI to do multiprocessing
 +   LIB - build a HyPhy library (libhyphy_mp) using pthreads to do multiprocessing


### PR DESCRIPTION
This patch adds a new target (SP) to CMake which allows building a single-threaded command-line version of hyphy. 
