### PR TITLE
Fixed a (minor) convergence failure bug in BranchSiteREL.bf

### DIFF
--- a/res/TemplateBatchFiles/BranchSiteREL.bf
+++ b/res/TemplateBatchFiles/BranchSiteREL.bf
@@ -541,7 +541,16 @@ for	(k = 0; k < totalBranchCount; k += 1) {
             lfOut	= csvFilePath + ".fit";
             _BSREL_json["convergence failures"] += 1;
             Optimize					  (res_three_LF,three_LF);
-            json_store_lf                 (_BSREL_json, "BS-REL", res_three_LF[1][0], res_three_LF[1][1] + 9, getIC (res_three_LF[1][0], res_three_LF[1][1], sample_size), _BSREL_timers[2]); 
+            json_store_lf                 ( _BSREL_json,
+                                            "BS-REL",
+                                            res_three_LF[1][0],
+                                            res_three_LF[1][1] + 9,
+                                            getIC(  res_three_LF[1][0],
+                                                    res_three_LF[1][1],
+                                                    sample_size),
+                                            _BSREL_timers[2],
+                                            +BranchLength (T, -1),
+                                            renderString);
             LIKELIHOOD_FUNCTION_OUTPUT = 7;
             fprintf (lfOut, CLEAR_FILE, three_LF);
             LIKELIHOOD_FUNCTION_OUTPUT = 2;


### PR DESCRIPTION
Upon convergence failure a call is made to write the json file. HyPhy crashed because this call failed to provide enough arguments. Fixed. Tested.

It should be noted that the last two arguments are not updated after the optimization of the full model.
