### PR TITLE
Adding `look_for_newick_tree` parameter to `io.getTreeString`

### DIFF
--- a/res/TemplateBatchFiles/BUSTED.bf
+++ b/res/TemplateBatchFiles/BUSTED.bf
@@ -60,8 +60,8 @@ codon_data_info = utility.promptForGeneticCodeAndAlignment ("codon_data", "codon
 codon_data_info["json"] = codon_data_info["file"] + ".BUSTED.json";
 io.reportProgressMessage ("BUSTED", "Loaded an MSA with " + codon_data_info["sequences"] + " sequences and " + codon_data_info["sites"] + " codons from '" + codon_data_info["file"] + "'");
 
-codon_frequencies     = utility.defineFrequencies ("codon_filter");
-tree_definition 	  = utility.loadAnnotatedTopology ();
+codon_frequencies = utility.defineFrequencies ("codon_filter");
+tree_definition   = utility.loadAnnotatedTopology(1);
 
 busted.selected_branches = busted.io.selectBranchesToTest (tree_definition);
 _BUSTED_json ["test set"] = Join (",",Rows(busted.selected_branches));

--- a/res/TemplateBatchFiles/RELAX.bf
+++ b/res/TemplateBatchFiles/RELAX.bf
@@ -79,7 +79,7 @@ relax.codon_data_info["json"] = relax.codon_data_info["file"] + ".RELAX.json";
 io.reportProgressMessage ("RELAX", "Loaded an MSA with " + relax.codon_data_info["sequences"] + " sequences and " + relax.codon_data_info["sites"] + " codons from '" + relax.codon_data_info["file"] + "'");
 
 relax.codon_frequencies     = utility.defineFrequencies ("RELAX.codon_filter");
-relax.tree 	  = utility.loadAnnotatedTopology ();
+relax.tree 	  = utility.loadAnnotatedTopology (1);
 
 relax.selected_branches = relax.io.defineBranchSets (relax.tree);
 RELAX.has_unclassified = utility.array.find (Rows (relax.selected_branches), RELAX.unclassified) >= 0;

--- a/res/TemplateBatchFiles/lib2014/IOFunctions.bf
+++ b/res/TemplateBatchFiles/lib2014/IOFunctions.bf
@@ -11,8 +11,14 @@ function io.readCodonDataSet (dataset_name) {
     return {"code": _Genetic_Code, "stop" : GeneticCodeExclusions, "file" : LAST_FILE_PATH, "sequences" : Eval ("`dataset_name`.species")};
 }
 
-function io.getTreeString () {
+function io.getTreeString (look_for_newick_tree) {
+
     UseModel (USE_NO_MODEL);
+
+    if(look_for_newick_tree == 0) {
+      IS_TREE_PRESENT_IN_DATA = 0;
+    }
+
     ExecuteAFile (HYPHY_LIB_DIRECTORY + "TemplateBatchFiles" 
                                       + DIRECTORY_SEPARATOR 
                                       + "queryTree.bf");
@@ -23,7 +29,6 @@ function io.checkAssertion (statement, error_msg) {
     ExecuteCommands ("assert (`statement`, error_msg)");
     return None;
 }
-
 
 function io.reportProgressMessage (analysis, text) {
     if (Abs (analysis)) {
@@ -88,8 +93,6 @@ function io.printAndUnderline (string, char) {
     }
     fprintf (stdout, "\n");
 }
-
-
 
 function io.formatLongStringToWidth (string, width) {
     words = splitOnRegExp (string, "[\\ \n]+");

--- a/res/TemplateBatchFiles/lib2014/UtilityFunctions.bf
+++ b/res/TemplateBatchFiles/lib2014/UtilityFunctions.bf
@@ -11,7 +11,6 @@ function utility.promptForGeneticCodeAndAlignment (dataset_name, datafilter_name
     return data_info;
 }
 
-
 function utility.defineFrequencies (datafilter_name) {
     HarvestFrequencies	          (nuc3, *datafilter_name, 3, 1, 1);
     nucCF						= CF3x4	(nuc3, GeneticCodeExclusions);
@@ -21,12 +20,10 @@ function utility.defineFrequencies (datafilter_name) {
             "codon": codon3x4};
 }
 
-function utility.loadAnnotatedTopology () {
-
-    tree_string = io.getTreeString();
+function utility.loadAnnotatedTopology (look_for_newick_tree) {
+    tree_string = io.getTreeString(look_for_newick_tree);
     Topology     T = tree_string;
     GetInformation (modelMap, T);
-        
     
     return {"string"     : Format (T,1,0),
             "model_map"  : modelMap,


### PR DESCRIPTION
Adding `look_for_newick_tree` parameter to `io.getTreeString` to avoid being asked whether the user wants to use a newick tree when there is one found in a multiple sequence alignment file. 
