### PR TITLE
Fixes #451 and fixes #421

### DIFF
--- a/src/utils/hyphyunixutils.cpp
+++ b/src/utils/hyphyunixutils.cpp
@@ -161,6 +161,7 @@ bool    Get_a_URL (_String& urls, _String* fileName)
 
 _String*    StringFromConsole   (bool)
 {
+    fflush(stdout);
     _String * returnme = new _String (32L, true);
 #if not defined __HEADLESS__ && not defined _MINGW32_MEGA_
     int       readAChar;


### PR DESCRIPTION
Flush stdout before reading in characters in order to ensure correct order of execution on multi-process or multi-threaded code.