### PR TITLE
JSON input tree fix

### DIFF
--- a/res/TemplateBatchFiles/SelectionAnalyses/BranchSiteREL.bf
+++ b/res/TemplateBatchFiles/SelectionAnalyses/BranchSiteREL.bf
@@ -135,7 +135,7 @@ _BSREL.json_path = _BSREL.output_prefix + ".json";
 
 
 (_BSREL_json[terms.json.input])[terms.json.file] = filename;
-(_BSREL_json[terms.json.input])[terms.json.tree_string] = tree_info[terms.trees.newick_with_lengths];
+(_BSREL_json[terms.json.input])[terms.json.tree_string] = tree_info[terms.trees.newick_with_lengths]; // TODO: without lengths if there are none.
 (_BSREL_json[terms.json.input])[terms.json.sequences] = ds.species;
 (_BSREL_json[terms.json.input])[terms.json.sites] = ds.sites/3;
 

--- a/res/TemplateBatchFiles/SelectionAnalyses/modules/shared-load-file.bf
+++ b/res/TemplateBatchFiles/SelectionAnalyses/modules/shared-load-file.bf
@@ -136,6 +136,9 @@ function load_file (prefix) {
         selected_branches = selection.io.defineBranchSets(partitions_and_trees);
     }
 
+    // Place in own attribute called `tested`
+     selection.io.json_store_key_value_pair (json, None, utility.getGlobalValue("terms.json.tested"), selected_branches);
+
         /**  this will return a dictionary of selected branches; one set per partition, like in
         {
             "0": {
@@ -165,18 +168,25 @@ function load_file (prefix) {
     (json[utility.getGlobalValue("terms.json.input")])[utility.getGlobalValue("terms.json.sites")] = codon_data_info[utility.getGlobalValue("terms.data.sites")];
     (json[utility.getGlobalValue("terms.json.input")])[utility.getGlobalValue("terms.json.partition_count")] = partition_count;
 
-    // The trees should go into input as well and they should be w/ their branch lengths
-
-     selection.io.json_store_key_value_pair (json,
+    // The trees should go into input as well and they should be w/ their branch lengths but ONLY if they have any.
+    t = (partitions_and_trees["0"])[utility.getGlobalValue("terms.data.tree")];
+    abs_branch_lengths = Abs(t[utility.getGlobalValue("terms.branch_length")]);
+    console.log(abs_branch_lengths);
+    
+    
+    if (abs_branch_lengths == 0){
+        selection.io.json_store_key_value_pair (json,
+                                             utility.getGlobalValue("terms.json.input"), utility.getGlobalValue("terms.json.trees"),
+                                             utility.Map (partitions_and_trees, "_pt_", '(_pt_[terms.data.tree])[terms.trees.newick]')
+                                             );    
+    } else {    
+        selection.io.json_store_key_value_pair (json,
                                              utility.getGlobalValue("terms.json.input"), utility.getGlobalValue("terms.json.trees"),
                                              utility.Map (partitions_and_trees, "_pt_", '(_pt_[terms.data.tree])[terms.trees.newick_with_lengths]')
-                                             );
+                                             ); 
+    }
 
 
-
-
-    // Place in own attribute called `tested`
-     selection.io.json_store_key_value_pair (json, None, utility.getGlobalValue("terms.json.tested"), selected_branches);
 
 
      filter_specification = alignments.DefineFiltersForPartitions (partitions_and_trees, "`prefix`.codon_data" , "`prefix`.filter.", codon_data_info);


### PR DESCRIPTION
Addressed bug where -1 was being printed for branch lengths. Now checks to see if input tree has branch lengths and then saves to JSON with or without lengths accordingly