### PR TITLE
Addition of binaryML model, allowing optimization of states frequencies

### DIFF
--- a/res/TemplateBatchFiles/libv3/models/binary/empirical.bf
+++ b/res/TemplateBatchFiles/libv3/models/binary/empirical.bf
@@ -1,0 +1,23 @@
+LoadFunctionLibrary("../protein.bf");
+LoadFunctionLibrary("../parameters.bf");
+LoadFunctionLibrary("../frequencies.bf");
+LoadFunctionLibrary("../../UtilityFunctions.bf");
+LoadFunctionLibrary("../../all-terms.bf");
+
+models.protein.empirical.default_generators = {"binary": "models.binary.ModelDescription"};
+                             
+
+models.binary.empirical.mleF_generators = {"binary": "models.binaryML.ModelDescription"};
+
+/**
+ * @name models.binary.ModelDescription
+ * @description Create the baseline schema (dictionary) for the binary model of character evolution
+ * @returns {Dictionary} model description
+ * @param {String} type
+ */
+function models.binaryML.ModelDescription(type) {
+    models.binaryML.ModelDescription.model_definition = models.binary.ModelDescription(type);
+    models.binaryML.ModelDescription.model_definition [terms.model.frequency_estimator] = "frequencies.ML.binary";
+    models.binaryML.ModelDescription.model_definition [terms.model.efv_estimate_name]   =  utility.getGlobalValue("terms.frequencies.MLE");
+    return models.binaryML.ModelDescription.model_definition;
+}

--- a/res/TemplateBatchFiles/libv3/models/frequencies.bf
+++ b/res/TemplateBatchFiles/libv3/models/frequencies.bf
@@ -80,7 +80,7 @@ function frequencies.empirical.protein (model, namespace, datafilter) {
  */
 function frequencies.ML.binary (model, namespace, datafilter) {
     model = frequencies._aux.empirical.singlechar(model, namespace, datafilter);
-    // define 20 frequency parameters
+    // define 2 frequency parameters
     // initialize to empirical freqs
     // add to model parameter manifest
     frequencies.ML.binary.emp = model[terms.efv_estimate];


### PR DESCRIPTION
Added a new function to libv3/models/frequencies.bf a new function `frequencies.ML.binary` based on the function `frequencies.ML.protein`.

Added a new file under directory libv3/models/binary by the name empirical.bf, based on the file libv3/models/proteins/empirical.bf.

Added a test /scratch300/halabikeren/hyphy/tests/hbltests/libv3/models/binaryML.bf, an input data for the text /scratch300/halabikeren/hyphy/tests/hbltests/libv3/data/binary.fas.

