### PR TITLE
Specify re_comp and re_exec function names with 'C' linkage

### DIFF
--- a/src/core/include/gnuregex.h
+++ b/src/core/include/gnuregex.h
@@ -466,8 +466,8 @@ _RE_ARGS ((struct re_pattern_buffer *buffer, struct re_registers *regs,
            unsigned num_regs, regoff_t *starts, regoff_t *ends));
 
 /* 4.2 bsd compatibility.  */
-extern char *re_comp _RE_ARGS ((const char *));
-extern int re_exec _RE_ARGS ((const char *));
+extern "C" char *re_comp _RE_ARGS ((const char *));
+extern "C" int re_exec _RE_ARGS ((const char *));
 
 /* POSIX compatibility.  */
 extern int regcomp _RE_ARGS ((regex_t *preg, const char *pattern, int cflags));


### PR DESCRIPTION
This fixes a build error on FreeBSD 11.1 amd64 using the base c++ compiler, clang++
version 4.0.0.