### PR TITLE
On FreeBSD, do not link libdl

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -190,14 +190,22 @@ endif(NOT ${OPENMP_FOUND})
 #-------------------------------------------------------------------------------
 set(INSTALL_PREFIX /usr/local CACHE PATH "Installation prefix")
 set(CMAKE_INSTALL_PREFIX ${INSTALL_PREFIX} CACHE INTERNAL "Installation prefix" FORCE)
-set(DEFAULT_LIBRARIES dl pthread)
+if(CMAKE_SYSTEM_NAME MATCHES "FreeBSD")
+    set(DEFAULT_LIBRARIES pthread)
+else(CMAKE_SYSTEM_NAME MATCHES "FreeBSD")
+    set(DEFAULT_LIBRARIES dl pthread)
+endif(CMAKE_SYSTEM_NAME MATCHES "FreeBSD")
 
 #-------------------------------------------------------------------------------
 # LIBCurl support
 #-------------------------------------------------------------------------------
 find_package(CURL)
 if(${CURL_FOUND} AND NOT APPLE)
-    set(DEFAULT_LIBRARIES dl pthread crypto curl ssl)
+    if(CMAKE_SYSTEM_NAME MATCHES "FreeBSD")
+        set(DEFAULT_LIBRARIES pthread crypto curl ssl)
+    else(CMAKE_SYSTEM_NAME MATCHES "FreeBSD")
+        set(DEFAULT_LIBRARIES dl pthread crypto curl ssl)
+    endif(CMAKE_SYSTEM_NAME MATCHES "FreeBSD")
     add_definitions (-D__HYPHYCURL__)
 endif(${CURL_FOUND} AND NOT APPLE)
 


### PR DESCRIPTION
The same functionality in GNU/Linux libdl is in libc on FreeBSD.
See https://www.freebsd.org/cgi/man.cgi?query=dlopen