### PR TITLE
Unit test script

### DIFF
--- a/run_unit_tests.sh
+++ b/run_unit_tests.sh
@@ -1,0 +1,38 @@
+# A simple script to run all unit tests against the currently checked out version
+
+currentDir=$PWD
+HYPHYMP=$PWD/HYPHYMP
+
+testsRun=0
+testsFailed=0
+failedTests=()
+
+for filename in ./tests/hbltests/UnitTests/HBLCommands/*.bf; do
+
+  # Run the test checking to see if it faield
+  if $HYPHYMP $filename | grep -q "TEST FAILED"; then
+    ((testFailed++))
+    failedTests+=($filename)
+  fi
+
+  ((testsRun++))
+  
+done
+
+echo "\n\n------------------------SUMMARY (Failed Tests)----------------------------\n"
+echo "\n The following tests failed:"
+
+for failedTest in "${failedTests[@]}"; do
+  $failedTest
+done
+
+echo "\n The output of the failed tests is below: \n"
+for failedTest in "${failedTests[@]}"; do
+  echo "--------------------------------------------------------------"
+  $HYPHYMP $failedTest
+  echo "\n"
+done
+
+echo "\n\n------------------------SUMMARY (Failed Tests)----------------------------\n"
+echo "$testFailed Tests Failed"
+echo "of $testsRun Tests Run"


### PR DESCRIPTION
This is the bash script that I'm using to run all the unit tests against the current version of HYPHY. I would like to update it to also run against version 2.3.14.

running `sh run_unit_tests.sh` produces an output like this:

![screen shot 2018-12-17 at 5 05 22 pm](https://user-images.githubusercontent.com/25244432/50118583-14a2d180-021e-11e9-93e2-dc4ddbcec020.png)
