### PR TITLE
Use tree if present in fasta file

### DIFF
--- a/res/TemplateBatchFiles/libv3/tasks/trees.bf
+++ b/res/TemplateBatchFiles/libv3/tasks/trees.bf
@@ -1,3 +1,4 @@
+
 LoadFunctionLibrary("../IOFunctions.bf");
 LoadFunctionLibrary("../all-terms.bf");
 LoadFunctionLibrary("../convenience/regexp.bf");
@@ -86,7 +87,7 @@ lfunction trees.GetTreeString._sanitize(string) {
     if (utility.GetEnvVariable("_DO_TREE_REBALANCE_")) {
         string = RerootTree(string, 0);
     }
-
+ 
     if (utility.GetEnvVariable("_KEEP_I_LABELS_")) {
         utility.ToggleEnvVariable("INTERNAL_NODE_PREFIX", "intNode");
     }
@@ -125,16 +126,8 @@ lfunction trees.GetTreeString(look_for_newick_tree) {
         }
 
         if (utility.GetEnvVariable("IS_TREE_PRESENT_IN_DATA")) {
-            fprintf(stdout, "\n\n>A tree was found in the data file: ``", utility.GetEnvVariable("DATAFILE_TREE"), "``\n\n>Would you like to use it (y/n)? ");
-            fscanf(stdin, "String", response);
-            if (response == "n" || response == "N") {
-                utility.SetEnvVariable("IS_TREE_PRESENT_IN_DATA", FALSE);
-                IS_TREE_PRESENT_IN_DATA = 0;
-            } else {
-                treeString = trees.GetTreeString._sanitize(utility.GetEnvVariable("DATAFILE_TREE"));
-                utility.SetEnvVariable("IS_TREE_PRESENT_IN_DATA", TRUE);
-            }
-            fprintf(stdout, "\n\n");
+            treeString = trees.GetTreeString._sanitize(utility.GetEnvVariable("DATAFILE_TREE"));
+            utility.SetEnvVariable("IS_TREE_PRESENT_IN_DATA", TRUE);
         }
 
         if (!utility.GetEnvVariable("IS_TREE_PRESENT_IN_DATA")) {

--- a/res/TemplateBatchFiles/libv3/tasks/trees.bf
+++ b/res/TemplateBatchFiles/libv3/tasks/trees.bf
@@ -1,4 +1,3 @@
-
 LoadFunctionLibrary("../IOFunctions.bf");
 LoadFunctionLibrary("../all-terms.bf");
 LoadFunctionLibrary("../convenience/regexp.bf");
@@ -87,7 +86,7 @@ lfunction trees.GetTreeString._sanitize(string) {
     if (utility.GetEnvVariable("_DO_TREE_REBALANCE_")) {
         string = RerootTree(string, 0);
     }
- 
+
     if (utility.GetEnvVariable("_KEEP_I_LABELS_")) {
         utility.ToggleEnvVariable("INTERNAL_NODE_PREFIX", "intNode");
     }


### PR DESCRIPTION
@srwis This should fix the issue you were having when trying to run BUSTED form the command line with a fasta file that also has a tree. Could you check this out and confirm that it works for you?