### PR TITLE
revert one change for ReplicateConstraint unit test

### DIFF
--- a/src/core/batchlanruntime.cpp
+++ b/src/core/batchlanruntime.cpp
@@ -1316,7 +1316,7 @@ bool      _ElementaryCommand::HandleReplicateConstraint (_ExecutionList& current
             _CalcNode * this_object = (_CalcNode *)_CheckForExistingVariableByType (*GetIthParameter(k), current_program, TREE | TREE_NODE);
             if (this_object->ObjectClass () == TREE) {
                 traversers[k-1] = new _TreeIterator ((_TheTree*)this_object, _HY_TREE_TRAVERSAL_POSTORDER);
-                parent_object_names << this_object->GetName();
+                parent_object_names << this_object->ParentTree()->GetName();
             } else {
                 node<long> * cn = this_object->LocateMeInTree();
                 if (!cn) {


### PR DESCRIPTION
@spond This change https://github.com/veg/hyphy/commit/2c5e9097abf89b986171cf1781be69b2dfe1810a#diff-8b07afdd835d9a39fd476d1efc59ba3eL1322 is causing the ReplicateConstraint Unit test to fail: https://travis-ci.org/veg/hyphy/jobs/517834943#L828.

This PR reverts that line and the unit test now passes but I wanted to check with you to see if the change is necessary and if so how to proceed. 