### PR TITLE
Fix FreeBSD compiler errors that affect version 2.5.0

### DIFF
--- a/src/contrib/regex.cpp
+++ b/src/contrib/regex.cpp
@@ -31,7 +31,12 @@
 #pragma alloca
 #endif
 
-#if !defined REGEX_MALLOC && !defined __MINGW32__
+/* alloca.h does not exist on Free- and OpenBSD, but is defined in the
+   standard library.
+
+   https://www.freebsd.org/cgi/man.cgi?query=alloca
+   https://man.openbsd.org/alloca */
+#if !defined REGEX_MALLOC && !defined __MINGW32__ && !defined __UNIX__
 #include <alloca.h>
 #endif
 

--- a/src/core/avllistx_iterator.cpp
+++ b/src/core/avllistx_iterator.cpp
@@ -84,7 +84,7 @@ AVLListXIteratorKeyValue const  AVLListXIterator::operator* (void) {
   if (this->current_location >= 0) {
     return AVLListXIteratorKeyValue (this->current_location, the_list->GetXtra(this->current_location));
   }
-  return AVLListXIteratorKeyValue (AVL_LISTX_ITERATOR_ENDINDEX,nil);
+  return AVLListXIteratorKeyValue (AVL_LISTX_ITERATOR_ENDINDEX,0);
 }
 
 bool AVLListXIterator::operator == (AVLListXIterator const & compare) {

--- a/src/core/batchlan.cpp
+++ b/src/core/batchlan.cpp
@@ -3122,7 +3122,7 @@ void      _ElementaryCommand::ExecuteCase52 (_ExecutionList& chain) {
         _String filter_specification = *GetFilterName (filter_id) & spawning_tree->GetName()->Enquote(',') & *freq_var->GetName();
 
 
-        bool    do_internals = parameters.countitems() > 5 ? (ProcessNumericArgument ((_String*)parameters (5),chain.nameSpacePrefix)>0.5) : nil;
+        bool    do_internals = parameters.countitems() > 5 ? (ProcessNumericArgument ((_String*)parameters (5),chain.nameSpacePrefix)>0.5) : false;
 
         _String spool_file;
 

--- a/src/core/dataset.cpp
+++ b/src/core/dataset.cpp
@@ -693,7 +693,7 @@ void _DataSet::MatchIndices(_Formula &f, _SimpleList &receptacle, bool isVert,
   // ? scope->sData : "none", varName.sData, ((_String*)f.toStr())->sData);
 
   for (long i = 0L; i < limit; i++) {
-    v->SetValue(new _Constant((hyFloat)i), nil);
+    v->SetValue(new _Constant((hyFloat)i), false);
     HBLObjectRef res = f.Compute();
     // fprintf (stderr, "%ld %g\n", i, res->Compute()->Value());
     if (res && !CheckEqual(res->Value(), 0.0)) {


### PR DESCRIPTION
Hello,

When building hyphy on the latest FreeBSD release (12.0), I encountered build errors.  These changes allow hyphy to build on FreeBSD, however I did not test them on other platforms.

-- Joseph