### PR TITLE
Make keyword arguments for gard and bgm consistent

### DIFF
--- a/res/TemplateBatchFiles/BGM.bf
+++ b/res/TemplateBatchFiles/BGM.bf
@@ -60,10 +60,10 @@ selection.io.startTimer (bgm.json [terms.json.timers], "Overall", 0);
 bgm.data_types = {terms.nucleotide  : "Nucleotide multiple sequence alignment",
                  terms.amino_acid   : "Protein multiple sequence alignment",
                  terms.codon        : "Codon multiple sequence alignment"};
-KeywordArgument ("run_type", "nucleotide, amino-acid or codon", "codon");
-bgm.run_type = io.SelectAnOption (bgm.data_types, "Data type");
+KeywordArgument ("type", "nucleotide, amino-acid or codon", "codon");
+bgm.type = io.SelectAnOption (bgm.data_types, "Data type");
 
-SetDialogPrompt ("Specify a `bgm.run_type` multiple sequence alignment file");
+SetDialogPrompt ("Specify a `bgm.type` multiple sequence alignment file");
 
 bgm.fit_options = {terms.run_options.retain_lf_object : TRUE};
 bgm.reporting_thershold = 0.5;
@@ -74,7 +74,7 @@ bgm.run_settings = {
     "samples" : 100,
     "max-parents" : 1,
     "min-subs" : 1,
-    "data-type" : bgm.run_type,
+    "data-type" : bgm.type,
     "threshold" : bgm.reporting_thershold
 };
 
@@ -83,11 +83,11 @@ KeywordArgument ("alignment", "An in-frame codon alignment in one of the formats
 KeywordArgument ("tree", "A phylogenetic tree (optionally annotated with {})", null, "Please select a tree file for the data:");
 KeywordArgument ("branches",  "Branches to test", "All");
 
-if (bgm.run_type == "nucleotide") {
+if (bgm.type == "nucleotide") {
    bgm.alignment_info = alignments.ReadNucleotideDataSet ("bgm.dataset", None);
    bgm.baseline_model = "models.DNA.GTR.ModelDescription";
 } else {
-    if (bgm.run_type == "amino-acid") {
+    if (bgm.type == "amino-acid") {
         bgm.alignment_info = alignments.ReadProteinDataSet ("bgm.dataset", None);
         LoadFunctionLibrary     ("libv3/models/protein.bf");
         LoadFunctionLibrary     ("libv3/models/protein/empirical.bf");
@@ -112,7 +112,7 @@ bgm.name_mapping = bgm.alignment_info[utility.getGlobalValue("terms.data.name_ma
 selection.io.json_store_key_value_pair (bgm.json, terms.json.input, terms.json.file, bgm.alignment_info [terms.data.file]);
 selection.io.json_store_key_value_pair (bgm.json, terms.json.input, terms.json.sequences, bgm.alignment_info [terms.data.sequences]);
 selection.io.json_store_key_value_pair (bgm.json, terms.json.input, terms.json.sites, bgm.alignment_info [terms.data.sites]);
-selection.io.json_store_key_value_pair (bgm.json, terms.json.input, terms.data_type, bgm.run_type);
+selection.io.json_store_key_value_pair (bgm.json, terms.json.input, terms.data_type, bgm.type);
 
 bgm.alignment_info[terms.json.json] = bgm.alignment_info[terms.data.file] + ".BGM.json";
 
@@ -133,7 +133,7 @@ bgm.filter_specification = alignments.DefineFiltersForPartitions (bgm.partitions
 bgm.store_tree_information();
 
 io.ReportProgressMessageMD ("BGM", "Data", "Loaded **" +
-                            bgm.alignment_info [terms.data.sequences] + "** `bgm.run_type` sequences, **" +
+                            bgm.alignment_info [terms.data.sequences] + "** `bgm.type` sequences, **" +
                             bgm.alignment_info [terms.data.sites] + "** sites, from \`" + bgm.alignment_info [terms.data.file] + "\`");
 
 bgm.initial_values = parameters.helper.tree_lengths_to_initial_values (bgm.trees, None);
@@ -165,7 +165,7 @@ selection.io.startTimer (bgm.json [terms.json.timers], "Baseline fit", 1);
 
 io.ReportProgressMessageMD("bgm", "phylo", "Performing initial model fit to obtain branch lengths and rate parameters");
 
-if (bgm.run_type == "nucleotide") {
+if (bgm.type == "nucleotide") {
    bgm.initial_values = utility.Extend (bgm.initial_values,
                                   {
                                     utility.getGlobalValue ("terms.global") : {
@@ -177,7 +177,7 @@ if (bgm.run_type == "nucleotide") {
                                  });
 
  } else {
-    if (bgm.run_type == "codon") {
+    if (bgm.type == "codon") {
         bgm.initial_values = utility.Extend (bgm.initial_values,
                                   {
                                     utility.getGlobalValue ("terms.global") : {
@@ -206,7 +206,7 @@ if (bgm.run_type == "nucleotide") {
     }
  }
 
-if (bgm.run_type == "codon") {
+if (bgm.type == "codon") {
     //codon_data, tree, generator, genetic_code, option, initial_values
     bgm.baseline_fit = estimators.FitCodonModel(
                                                      bgm.filter_names,
@@ -259,7 +259,7 @@ bgm.ancestral_cache = ancestral.build (bgm.baseline_fit[terms.likelihood_functio
 bgm.branch_filter = utility.Filter (bgm.selected_branches[0], "_class_", "_class_ == terms.tree_attributes.test");
 DeleteObject (^bgm.baseline_fit[terms.likelihood_function]);
 
-if (bgm.run_type != "codon") {
+if (bgm.type != "codon") {
    bgm.counts = ancestral.ComputeSubstitutionCounts(
         bgm.ancestral_cache,
         bgm.branch_filter,  // selected branches

--- a/res/TemplateBatchFiles/GARD.bf
+++ b/res/TemplateBatchFiles/GARD.bf
@@ -72,9 +72,9 @@ gard.analysisDescription = {terms.io.info : "GARD : Genetic Algorithms for Recom
                           };
 
 namespace terms.gard {
-    nucleotide = "Nucleotide";
-    protein    = "Protein";
-    codon      = "Codon";
+    nucleotide = "nucleotide";
+    protein    = "amino-acid";
+    codon      = "codon";
 };
 
 gard.json = {   terms.json.analysis: gard.analysisDescription,
@@ -86,7 +86,7 @@ gard.json = {   terms.json.analysis: gard.analysisDescription,
 ------------------------------------------------------------------------------*/
 io.DisplayAnalysisBanner (gard.analysisDescription);
 
-KeywordArgument ("type",        "The type of data to perform screening on", "Nucleotide");
+KeywordArgument ("type",        "The type of data to perform screening on", "nucleotide");
 KeywordArgument ("code",        "Genetic code to use (for codon alignments)", "Universal", "Choose Genetic Code");
 KeywordArgument ("alignment",   "Sequence alignment to screen for recombination");
 

--- a/test_kwargs.sh
+++ b/test_kwargs.sh
@@ -174,10 +174,10 @@ declare -a fileTypes=(  "--alignment ./tests/hbltests/data/CD2.nex" # nexus with
 
 # GARD
 declare -a gardArgs=(   ""
-                        "--type Nucleotide"
-                        "--type Codon"
-                        "--type Codon --code Universal"
-                        "--type Codon --model JTT"
+                        "--type nucleotide"
+                        "--type codon"
+                        "--type codon --code Universal"
+                        "--type codon --model JTT"
                         "--rv GDD"
                         "--rv GDD --rate-classes 2"
                         "--output ./testMethodOutput"


### PR DESCRIPTION
Previously:
- BGM used: `--run_type` with the options of `codon`, `amino-acid` or `nucleotide` 
- GARD used: `--type` with the options of `Codon`, `Protein` or `Nucleotide`

This pull request changes the code to make them consistent. Both now use:
 - `--type` with the options of `codon`, `amino-acid` or `nucleotide`