### PR TITLE
Fix build using NOAVX

### DIFF
--- a/src/core/matrix.cpp
+++ b/src/core/matrix.cpp
@@ -3128,8 +3128,6 @@ void    _Matrix::AddMatrix  (_Matrix& storage, _Matrix& secondArg, bool subtract
                      CELL_OP (idx+8);
                      CELL_OP (idx+12);
                  }
-            }
-
  #else
                 for (long idx = 0; idx < upto; idx+=4) {
                     stData[idx]+=argData[idx];
@@ -3138,7 +3136,7 @@ void    _Matrix::AddMatrix  (_Matrix& storage, _Matrix& secondArg, bool subtract
                     stData[idx+3]+=argData[idx+3];
                 }
 #endif
-                
+            }
             if (subtract)
                 for (long idx = upto; idx < secondArg.lDim; idx++) {
                     stData[idx]-=argData[idx];


### PR DESCRIPTION
Without this patch, building with NOAVX gives the error below.

hyphy-2.5.18/src/core/matrix.cpp: In member function 'void _Matrix::AddMatrix(_Matrix&, _Matrix&, bool)':
hyphy-2.5.18/src/core/matrix.cpp:3152:7: error: expected '}' before 'else'
 3152 |     } else
      |       ^~~~
hyphy-2.5.18/src/core/matrix.cpp:3047:23: note: to match this '{'
 3047 |     if (is_numeric()) {
      |                       ^