### PR TITLE
Fix v2.5.20 build error (cannot convert std::nullptr_t to hyFloat)

### DIFF
--- a/src/core/matrix.cpp
+++ b/src/core/matrix.cpp
@@ -2236,7 +2236,7 @@ bool    _Matrix::IncreaseStorage    (void) {
         } else {
             theData = (hyFloat*) MemReallocate(theData, lDim*sizeof(void*));
             for (long i = lDim-allocationBlock; i < lDim; i++) {
-                theData [i] = ZEROPOINTER;
+                theData [i] = ZEROOBJECT;
             }
         }
     } else {


### PR DESCRIPTION
Build log:
- [Before patching](http://pkg.awarnach.mathstat.dal.ca/data/12amd64-default/2020-10-16_19h17m06s/logs/errors/hyphy-2.5.20.log)
- [After patching](http://pkg.awarnach.mathstat.dal.ca/data/12amd64-default/2020-10-16_20h17m09s/logs/hyphy-2.5.20.log)