### PR TITLE
doc: Make build instructions less confusing

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,8 +63,7 @@ If building on a heterogeneous cluster with some nodes that do not support auto-
 If you're on a UNIX-compatible system, and you're comfortable with GNU make, then run `make` with one of the following build targets:
 
 +   MP or hyphy - build a HyPhy executable (This used to be "HYPHYMP" but is now just "hyphy") using pthreads to do multiprocessing
-+   MPI - build a HyPhy executable (HYPHYMPI) using MPI to do multiprocessing
-+   HYPHYMPI - build a HyPhy executable (HYPHYMPI) using openMPI 
++   MPI or HYPHYMPI - build a HyPhy executable (HYPHYMPI) using openMPI to do multiprocessing
 +   LIB - build a HyPhy library (libhyphy_mp) using pthreads to do multiprocessing
 -   GTEST - build HyPhy's gtest testing executable (HYPHYGTEST)
 


### PR DESCRIPTION
I was wondering whether MPI and HYPHYMPI were 2 different things because their description differed. They aren't. So let's use the `or` pattern here as well.
