### PR TITLE
Add support for --help=json flag to output structured command-line op…

### DIFF
--- a/res/TemplateBatchFiles/SelectionAnalyses/FEL.bf
+++ b/res/TemplateBatchFiles/SelectionAnalyses/FEL.bf
@@ -97,7 +97,7 @@ KeywordArgument ("code", "Which genetic code should be used", "Universal");
 KeywordArgument ("alignment", "An in-frame codon alignment in one of the formats supported by HyPhy");
 KeywordArgument ("tree", "A phylogenetic tree (optionally annotated with {})", null, "Please select a tree file for the data:");
 KeywordArgument ("branches",  "Branches to test", "All");
-KeywordArgument ("srv", "Include synonymous rate variation in the model", "Yes");
+KeywordArgument ("srv", "Include synonymous rate variation in the model", "Yes",  null, "string", {{"Yes", "[Recommended] Consider synonymous rate variation (dS varies across sites)."}, {"No", "Ignore synonymous rate variation (dS := 1 at each site)."}});
 KeywordArgument ("multiple-hits",  "Include support for multiple nucleotide substitutions", "None");
 KeywordArgument ("pvalue",  "The p-value threshold to use when testing for selection", "0.1");
 KeywordArgument ("ci",  "Compute profile likelihood confidence intervals for each variable site", "No");

--- a/src/core/batchlan.cpp
+++ b/src/core/batchlan.cpp
@@ -1347,7 +1347,6 @@ _StringBuffer const _ExecutionList::GenerateJsonHelpMessage(_AVLList * scanned_f
         if (sc.IsALiteralArgument(true)) {
             return sc;
         }
-        return sc & " [computed at run time]";
     };
 
     // Start building JSON manually

--- a/src/core/batchlan2.cpp
+++ b/src/core/batchlan2.cpp
@@ -428,17 +428,22 @@ const long cut, const long conditions, const char sep, const bool doTrim, const 
                                         false,
                                         &lengthOptions));
 
-    lengthOptions.Clear();lengthOptions.Populate (3,2,1);
-    _HY_HBLCommandHelper.Insert    ((BaseRef)HY_HBL_COMMAND_KEYWORD_ARGUMENT,
-                                    (long)_hyInitCommandExtras (_HY_ValidHBLExpressions.Insert ("KeywordArgument(", HY_HBL_COMMAND_KEYWORD_ARGUMENT,false),
-                                                                -1,
-                                                                "KeywordArgument (keyword, description, [default value, [dialog reference]])",
-                                                                ',',
-                                                                true,
-                                                                false,
-                                                                false,
-                                                                &lengthOptions));
+    lengthOptions.Clear();lengthOptions.Populate (5,2,1);
 
+    _HY_HBLCommandHelper.Insert(
+        (BaseRef)HY_HBL_COMMAND_KEYWORD_ARGUMENT,
+        (long)_hyInitCommandExtras(
+            _HY_ValidHBLExpressions.Insert("KeywordArgument(", HY_HBL_COMMAND_KEYWORD_ARGUMENT, false),
+            -1,
+            "KeywordArgument (keyword, description, [default value, [dialog reference, [type, [choices]]]])",
+            ',',
+            true,
+            false,
+            false,
+            &lengthOptions
+        )
+    );
+    
     lengthOptions.Clear();lengthOptions.Populate (2,3,1); // 3 or 4
     _HY_HBLCommandHelper.Insert    ((BaseRef)HY_HBL_COMMAND_GET_STRING, 
                                     (long)_hyInitCommandExtras (_HY_ValidHBLExpressions.Insert ("GetString(", HY_HBL_COMMAND_GET_STRING,false),

--- a/src/core/include/batchlan.h
+++ b/src/core/include/batchlan.h
@@ -139,6 +139,7 @@ public:
     }
     
     _StringBuffer const GenerateHelpMessage         (_AVLList * scanned_functions = nil) const;
+    _StringBuffer const GenerateJsonHelpMessage         (_AVLList * scanned_functions = nil) const;
     
     bool        IsErrorState    (void)     {
             return errorState;

--- a/src/mains/unix.cpp
+++ b/src/mains/unix.cpp
@@ -1004,14 +1004,6 @@ int main (int argc, char* argv[]) {
 
          ex.Execute();
 
-    if (displayJsonHelpAndExit) {
-        // --help returns the message below
-        //DisplayHelpMessage();
-        printf ("hola");
-        GlobalShutdown();
-        return 0;
-    }
-
  
         
 #ifdef __HYPHYMPI__

--- a/src/mains/unix.cpp
+++ b/src/mains/unix.cpp
@@ -155,6 +155,7 @@ _String baseArgDir,
 
 const   _String kLoggedFileEntry ("__USER_ENTRY__"),
                 kHelpKeyword     ("--help"),
+                kHelpJSONKeyword ("--help=json"),
                 kVersionKeyword  ("--version"),
                 kVerboseKeyword  ("--verbose");
 
@@ -173,7 +174,8 @@ bool    calculatorMode    = false,
         updateMode       = false,
         pipeMode         = false,
         logInputMode   = false,
-        displayHelpAndExit = false;
+        displayHelpAndExit = false,
+        displayJsonHelpAndExit = false;
 char    prefFileName[] = ".hyphyinit";
 
 #ifdef  __HYPHYMPI__
@@ -766,6 +768,11 @@ int main (int argc, char* argv[]) {
 
       if (thisArg.get_char(0)=='-') { // -[LETTER] arguments
           if (thisArg.get_char (1) == '-') {
+
+              if (thisArg == kHelpJSONKeyword) {
+                  displayJsonHelpAndExit = true;
+                  continue;
+              }
               if (thisArg == kHelpKeyword) {
                   displayHelpAndExit = true;
                   continue;
@@ -832,6 +839,7 @@ int main (int argc, char* argv[]) {
         GlobalShutdown();
         return 0;
     }
+
     
     //ObjectToConsole(&availableTemplateFilesAbbreviations);
     
@@ -977,8 +985,32 @@ int main (int argc, char* argv[]) {
             return 0;
         }
 
+        if (displayJsonHelpAndExit) {
+#ifdef __HYPHYMPI__
+            if (hy_mpi_node_rank == 0L) {
+#endif
+            NLToConsole();
+            StringToConsole(ex.GenerateJsonHelpMessage());
+            NLToConsole();
+#ifdef __HYPHYMPI__
+            }
+#endif
+            PurgeAll                    (true);
+            GlobalShutdown              ();
+            return 0;
+        }
+
+
 
          ex.Execute();
+
+    if (displayJsonHelpAndExit) {
+        // --help returns the message below
+        //DisplayHelpMessage();
+        printf ("hola");
+        GlobalShutdown();
+        return 0;
+    }
 
  
         


### PR DESCRIPTION
…tions

- Implement JSON-based help message generation
- Introduce `--help=json` flag for structured CLI output
- Properly parse and format keyword arguments and choice lists
- Default `type` to "string" if not explicitly specified
- Ensure valid JSON formatting for compatibility with external tools