### PR TITLE
Add WebAssembly build support via GitHub Actions

### DIFF
--- a/.github/workflows/webassembly.yml
+++ b/.github/workflows/webassembly.yml
@@ -1,0 +1,57 @@
+name: WebAssembly Build
+
+on:
+  push:
+    branches: [ master, develop, wasm ]
+  pull_request:
+    branches: [ master, develop ]
+  workflow_dispatch:
+
+jobs:
+  build_wasm:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      
+      - name: Setup Emscripten
+        uses: mymindstorm/setup-emsdk@v11
+        with:
+          version: 'latest'
+          actions-cache-folder: 'emsdk-cache'
+          
+      - name: Verify Emscripten
+        run: |
+          emcc --version
+          
+      - name: Configure
+        run: |
+          emcmake cmake -DCMAKE_EXE_LINKER_FLAGS="-sTOTAL_STACK=2097152 -O2 -sASSERTIONS=1 -sMODULARIZE=1 -sALLOW_MEMORY_GROWTH -sFORCE_FILESYSTEM=1 -sEXIT_RUNTIME=0 -s EXPORTED_RUNTIME_METHODS=['callMain','FS','PROXYFS','WORKERFS','UTF8ToString','getValue','AsciiToString'] -lworkerfs.js -lproxyfs.js -s INVOKE_RUN=0 -s ENVIRONMENT='web,worker' -fwasm-exceptions --preload-file res@/hyphy" .
+          
+      - name: Build
+        run: |
+          emmake make hyphy
+          
+      - name: Create WASM package
+        run: |
+          mkdir -p wasm-build
+          cp hyphy.js hyphy.wasm hyphy.data wasm-build/
+          
+      - name: Upload WebAssembly artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: hyphy-wasm
+          path: wasm-build/
+          
+      - name: Create release package
+        if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/develop' || github.ref == 'refs/heads/wasm'
+        run: |
+          cd wasm-build
+          zip -r ../hyphy-wasm.zip .
+          cd ..
+          
+      - name: Upload Zip as artifact
+        if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/develop' || github.ref == 'refs/heads/wasm'
+        uses: actions/upload-artifact@v3
+        with:
+          name: hyphy-wasm-zip
+          path: hyphy-wasm.zip


### PR DESCRIPTION
This PR adds a GitHub Actions workflow that builds HyPhy for WebAssembly using Emscripten.

The workflow will:
- Run on pushes to master, develop, and wasm branches
- Build the WebAssembly target with Emscripten
- Create build artifacts containing the WebAssembly binaries (hyphy.js, hyphy.wasm, hyphy.data)
- Package files as both directory and zip archives for easy distribution

This enables running HyPhy in web browsers and other WebAssembly environments.