### PR TITLE
Fix build on i386 (32-bit x86)

### DIFF
--- a/src/core/global_things.cpp
+++ b/src/core/global_things.cpp
@@ -173,7 +173,7 @@ hyPointer MemAllocate(size_t bytes, bool zero, size_t alignment) {
   result = (hyPointer)zero ? calloc(bytes, 1) : malloc(bytes);
 
   if (result == nil) {
-    HandleApplicationError(_String("Failed to allocate '") & bytes & "' bytes'",
+    HandleApplicationError(_String("Failed to allocate '") & (unsigned long)bytes & "' bytes'",
                            true);
   }
   return result;
@@ -186,7 +186,7 @@ hyPointer MemReallocate(hyPointer old_pointer, size_t new_size) {
 
   if (result == nil) {
     HandleApplicationError(
-        _String("Failed to resize memory to '") & new_size & "' bytes'", true);
+        _String("Failed to resize memory to '") & (unsigned long)new_size & "' bytes'", true);
   }
 
   return result;


### PR DESCRIPTION
After updating to 2.5.77, the build was failing on i386 with:

/wrkdirs/usr/ports/biology/hyphy/work/hyphy-2.5.77/src/core/global_things.cpp:176:62: error: conversion from 'size_t' (aka 'unsigned int') to 'const _String' is ambiguous
  176 |     HandleApplicationError(_String("Failed to allocate '") & bytes & "' bytes'",
      |                                                              ^~~~~

Fix the build by explicitly casting size_t variables to unsigned long when passing them to _String constructors.  _String has multiple constructors accepting numeric types (long, unsigned long, hyFloat, char), but not directly a size_t.