### PR TITLE
Enhance FEL branch selection documentation

### DIFF
--- a/res/TemplateBatchFiles/SelectionAnalyses/FEL.bf
+++ b/res/TemplateBatchFiles/SelectionAnalyses/FEL.bf
@@ -96,7 +96,7 @@ selection.io.startTimer (fel.json [terms.json.timers], "Total time", 0);
 KeywordArgument ("code", "Which genetic code should be used", "Universal");
 KeywordArgument ("alignment", "An in-frame codon alignment in one of the formats supported by HyPhy");
 KeywordArgument ("tree", "A phylogenetic tree (optionally annotated with {})", null, "Please select a tree file for the data:");
-KeywordArgument ("branches",  "Branches to test", "All");
+KeywordArgument ("branches",  "Branches to test. Options: 'All' (default), 'Internal', 'Leaves', 'Unlabeled', 'fg' (labeled branches), comma-separated branch names (e.g. 'Node1,Node2'), or regex patterns (e.g. '/^human/i')", "All");
 KeywordArgument ("srv", "Include synonymous rate variation in the model", "Yes");
 KeywordArgument ("multiple-hits",  "Include support for multiple nucleotide substitutions", "None");
 KeywordArgument ("pvalue",  "The p-value threshold to use when testing for selection", "0.1");


### PR DESCRIPTION
## Summary
- Enhanced the help documentation for the `branches` parameter in FEL.bf
- Added comprehensive descriptions of all branch selection options
- Included examples for custom branch lists and regex patterns

## Changes
- Updated the KeywordArgument for "branches" to include detailed usage information
- Help text now explains: 'All', 'Internal', 'Leaves', 'Unlabeled', 'fg' options
- Added examples for comma-separated branch names and regex patterns

## Test plan
- [x] Verified `hyphy fel --help` displays the enhanced documentation correctly
- [x] Confirmed all branch selection options are clearly explained
- [x] Ensured proper formatting and readability

🤖 Generated with [Claude Code](https://claude.ai/code)