### PR TITLE
URGENT: Fix HYPHYMPI build error - undeclared identifier 'return_value'

### DIFF
--- a/src/mains/unix.cpp
+++ b/src/mains/unix.cpp
@@ -972,6 +972,7 @@ int main(int argc, char *argv[]) {
   }
 
   _ExecutionList ex;
+  int return_value = 0;
 
 #ifdef __HYPHYMPI__
   if (hy_mpi_node_rank == 0L)
@@ -1110,7 +1111,6 @@ int main(int argc, char *argv[]) {
     }
 
     HBLObjectRef exectuion_result = ex.Execute();
-    int return_value = 0;
     if (exectuion_result && exectuion_result->ObjectClass() == NUMBER) {
       return_value = (int)(exectuion_result->Compute()->Value());
     }


### PR DESCRIPTION
## Summary
- Fixes build error in HYPHYMPI target where `return_value` was undeclared
- Moves `return_value` declaration to function scope to ensure availability in all code paths

## Problem
The `return_value` variable was declared inside a conditional block that only executes when MPI rank is 0. When building with `__HYPHYMPI__` defined and rank > 0, the code would take a different path and never declare `return_value`, causing a compilation error at line 1159.

## Solution
Moved the declaration of `return_value` to the function scope (line 975) so it's available for all execution paths, regardless of MPI rank.

## Test plan
- [x] Build HYPHYMPI target successfully completes
- [x] No compilation errors

🤖 Generated with [Claude Code](https://claude.ai/code)