### PR TITLE
Instructions for Homebrew

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,13 @@ HyPhy is an open-source software package for the analysis of genetic sequences u
 
 ## Quick Start
 
-#### Install
+The preferred method to install Hyphy is by using Conda:
+
 `conda install -c bioconda hyphy`
+
+Alternatively, you can install Hyphy using Homebrew:
+
+`brew install hyphy`
 
 #### Running with Docker
 You can also run HyPhy without having to install it on your system using the provided Dockerfile. Following the below instructions starts an interactive Docker container where HyPhy is already available. 


### PR DESCRIPTION
Hyphy is now [available](https://github.com/Homebrew/homebrew-core/commit/87f1d8911586e350f6113ac1aaffe1d9992d2761) to install via [Homebrew](https://brew.sh).