### PR TITLE
Fix segfault in NEXUS interleaved format parsing

### DIFF
--- a/src/core/nexus.cpp
+++ b/src/core/nexus.cpp
@@ -1301,11 +1301,12 @@ bool ProcessNexusData(FileState &fState, long pos, hyFile *f,
         loopIterations++;
         long expected_sites_before_sequence = fState.totalSitesRead;
         ISelector(fState, *source, result);
-        if (fState.curSpecies > 0) {
+        if (fState.curSpecies > 0 && !fState.interleaved) {
           if (expected_sites_before_sequence < fState.totalSitesRead) {
+            _String *seq_name = result.GetSequenceName(fState.curSpecies);
             HandleAlignmentValidationError(
                 _String("Sequence ") & (long)(fState.curSpecies + 1) & " " &
-                result.GetSequenceName(fState.curSpecies)->Enquote('(', ')') &
+                (seq_name ? seq_name->Enquote('(', ')') : _String("(unknown)")) &
                 " is longer " &
                 _String((long)fState.totalSitesRead).Enquote('(', ')') &
                 " than the expected length based on prior sequences " &


### PR DESCRIPTION
## Summary

Fixes a segfault (SIGSEGV) when parsing interleaved NEXUS files generated by R's `write.nexus.data`.

## Root Cause

The non-interleaved sequence length validation check at `nexus.cpp:1304` was incorrectly triggering for interleaved alignments. When processing the second interleave block, `totalSitesRead` increases (expected behavior for interleaved data), but the validation treated this as an error condition.

This caused `GetSequenceName(fState.curSpecies)` to be called with an out-of-bounds index (curSpecies wraps around in interleaved mode), returning `nullptr`, which then crashed in `_String::Enquote()`.

## Fix

- Add `!fState.interleaved` to the condition guard so the non-interleaved validation only applies to non-interleaved files
- Add null check on `GetSequenceName` result as a defensive measure

## Testing

- Reproduced the crash with the production dataset (12 taxa, 1602 chars, INTERLEAVE=YES NEXUS from R)
- Verified SLAC and RELAX both complete successfully with the fix
- The existing non-interleaved validation logic is unchanged for non-interleaved files

Fixes #1984